### PR TITLE
trying to support multiple sensors at once

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,12 +242,10 @@ module.exports = function(homebridge) {
 
                     that.fakeWeatherEveService.setCharacteristic(Characteristic.CurrentTemperature, that.temperature);
                     that.fakeWeatherEveService.setCharacteristic(Characteristic.CurrentRelativeHumidity, that.humidity);
-                    that.fakeWeatherEveService.setCharacteristic(CustomCharacteristic.AirPressure, that.airPressure);
 
                     that.loggingService.addEntry({
                         time: time.getTime() / 1000,
                         temp: that.temperature,
-                        pressure: that.airPressure,
                         humidity: that.humidity
                     });
 


### PR DESCRIPTION
Happy to talk about this more to get the PR into a better state but these are the changes I had to make to allow multiple sensors at once.

```
[6/11/2024, 12:53:54 PM] Error: Cannot add a Characteristic with the same UUID as another Characteristic in this Service: E863F10F-079E-48FF-8F27-9C2605A29F52
    at NetroSensor.EveService.WeatherService.Service.addCharacteristic (/homebridge/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Service.ts:589:15)
    at NetroSensor.EveService.WeatherService.Service.getCharacteristic (/homebridge/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Service.ts:691:29)
    at NetroSensor.EveService.WeatherService.Service.setCharacteristic (/homebridge/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Service.ts:758:10)
    at /homebridge/node_modules/homebridge-netro-whisperer/index.js:245:48
    at Request._callback (/homebridge/node_modules/homebridge-netro-whisperer/node_modules/homebridge-http-base/src/http.ts:95:13)
    at Request.self.callback (/homebridge/node_modules/homebridge-netro-whisperer/node_modules/request/request.js:185:22)
    at Request.emit (node:events:518:28)
    at Request.<anonymous> (/homebridge/node_modules/homebridge-netro-whisperer/node_modules/request/request.js:1154:10)
    at Request.emit (node:events:518:28)
    at IncomingMessage.<anonymous> (/homebridge/node_modules/homebridge-netro-whisperer/node_modules/request/request.js:1076:12)
```